### PR TITLE
fix(ionic-react): add @nrwl/react version based on the users Nx version

### DIFF
--- a/packages/ionic-react/CHANGELOG.md
+++ b/packages/ionic-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 3.0.3
+
+## Bug Fixes
+
+- add `@nrwl/react` version based on the users Nx version
+
 # 3.0.2
 
 ## Bug Fixes

--- a/packages/ionic-react/package.json
+++ b/packages/ionic-react/package.json
@@ -19,7 +19,6 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@nrwl/react": "*",
     "@nxtend/capacitor": "*"
   }
 }

--- a/packages/ionic-react/src/schematics/application/schematic.spec.ts
+++ b/packages/ionic-react/src/schematics/application/schematic.spec.ts
@@ -123,6 +123,18 @@ describe('application', () => {
 
   beforeEach(() => {
     appTree = createEmptyWorkspace(Tree.empty());
+    appTree.overwrite(
+      'package.json',
+      `
+      {
+        "name": "test-name",
+        "dependencies": {},
+        "devDependencies": {
+          "@nrwl/workspace": "0.0.0"
+        }
+      }
+    `
+    );
   });
 
   it('should add dependencies to package.json', async () => {

--- a/packages/ionic-react/src/schematics/init/lib/add-react-plugin.ts
+++ b/packages/ionic-react/src/schematics/init/lib/add-react-plugin.ts
@@ -1,0 +1,39 @@
+import {
+  chain,
+  externalSchematic,
+  noop,
+  Rule,
+  Tree,
+} from '@angular-devkit/schematics';
+import { addDepsToPackageJson, readJsonInTree } from '@nrwl/workspace';
+
+export function addReactPlugin(): Rule {
+  return (host: Tree) => {
+    const packageJson = readJsonInTree(host, 'package.json');
+
+    if (
+      !packageJson.dependencies['@nrwl/react'] &&
+      !packageJson.devDependencies['@nrwl/react']
+    ) {
+      const nxVersion = packageJson.devDependencies['@nrwl/workspace']
+        ? packageJson.devDependencies['@nrwl/workspace']
+        : packageJson.dependencies['@nrwl/workspace'];
+
+      if (!nxVersion) {
+        throw new Error('@nrwl/workspace is not installed as a dependency.');
+      }
+
+      return chain([
+        addDepsToPackageJson(
+          {},
+          {
+            '@nrwl/react': nxVersion,
+          }
+        ),
+        externalSchematic('@nrwl/react', 'init', {}),
+      ]);
+    } else {
+      return noop();
+    }
+  };
+}

--- a/packages/ionic-react/src/schematics/init/schematic.spec.ts
+++ b/packages/ionic-react/src/schematics/init/schematic.spec.ts
@@ -14,6 +14,18 @@ describe('init', () => {
 
   beforeEach(() => {
     appTree = createEmptyWorkspace(Tree.empty());
+    appTree.overwrite(
+      'package.json',
+      `
+      {
+        "name": "test-name",
+        "dependencies": {},
+        "devDependencies": {
+          "@nrwl/workspace": "0.0.0"
+        }
+      }
+    `
+    );
   });
 
   it('should add Ionic React dependencies', async () => {
@@ -21,11 +33,9 @@ describe('init', () => {
       .runSchematicAsync('init', {}, appTree)
       .toPromise();
     const packageJson = readJsonInTree(result, 'package.json');
+
     expect(packageJson.dependencies['@ionic/react']).toBeDefined();
     expect(packageJson.dependencies['ionicons']).toBeDefined();
-    expect(packageJson.dependencies['react']).toBeDefined();
-    expect(packageJson.dependencies['react-dom']).toBeDefined();
-    expect(packageJson.devDependencies['@nrwl/react']).toBeDefined();
     expect(packageJson.devDependencies['@nxtend/ionic-react']).toBeDefined();
     expect(
       packageJson.devDependencies['@testing-library/user-event']
@@ -33,6 +43,35 @@ describe('init', () => {
     expect(
       packageJson.devDependencies['@testing-library/jest-dom']
     ).toBeDefined();
+  });
+
+  it('should add and initialize Nrwl React plugin', async () => {
+    const result = await testRunner
+      .runSchematicAsync('init', {}, appTree)
+      .toPromise();
+    const packageJson = readJsonInTree(result, 'package.json');
+
+    expect(packageJson.devDependencies['@nrwl/react']).toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/react']).toEqual('0.0.0');
+
+    expect(packageJson.dependencies['react']).toBeDefined();
+    expect(packageJson.dependencies['react-dom']).toBeDefined();
+  });
+
+  it('should throw an error if Nrwl Workspace plugin is not installed', async () => {
+    appTree.overwrite(
+      'package.json',
+      `
+      {
+        "name": "test-name",
+        "dependencies": {},
+        "devDependencies": {}
+      }
+    `
+    );
+    await expect(
+      testRunner.runSchematicAsync('init', {}, appTree).toPromise()
+    ).rejects.toThrowError();
   });
 
   it('should set default collection', async () => {

--- a/packages/ionic-react/src/schematics/init/schematic.ts
+++ b/packages/ionic-react/src/schematics/init/schematic.ts
@@ -2,12 +2,13 @@ import { chain, noop, Rule } from '@angular-devkit/schematics';
 import { addPackageWithInit } from '@nrwl/workspace';
 import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace';
 import { addDependencies } from './lib/add-dependencies';
+import { addReactPlugin } from './lib/add-react-plugin';
 import { InitSchematicSchema } from './schema';
 
 export default function (options: InitSchematicSchema): Rule {
   return chain([
     setDefaultCollection('@nxtend/ionic-react'),
-    addPackageWithInit('@nrwl/react'),
+    addReactPlugin(),
     options.capacitor ? addPackageWithInit('@nxtend/capacitor') : noop(),
     addDependencies(),
   ]);


### PR DESCRIPTION
# Description

When the `@nxtend/ionic-react:init` schematic is executed and the user does not have the `@nrwl/react` plugin installed then it will add the `@nrwl/react` dependency with the latest version.

This change ensures that the version of `@nrwl/react` being added matches their `@nrwl/workspace` version to avoid unwanted side effects.

# PR Checklist

- [ ] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #182 
