### PR TITLE
fix(ionic-react): update schematics to better handle adding Nx plugins

### DIFF
--- a/packages/docs/docs/ionic-react/getting-started.md
+++ b/packages/docs/docs/ionic-react/getting-started.md
@@ -55,3 +55,7 @@ Options:
   --dryRun                Runs through and reports activity without writing to disk.
   --help                  Show available options for project target.
 ```
+
+## Troubleshooting
+
+If you receive a `Collection cannot be resolved` error when attempting to generate an application then you likely need to execute the [`@nxtend/ionic-react:init`](./schematics/init) schematic.

--- a/packages/docs/docs/ionic-react/schematics/init.md
+++ b/packages/docs/docs/ionic-react/schematics/init.md
@@ -13,6 +13,8 @@ This schematic adds the following dependencies:
 ```
 @ionic/react
 @ionic/react-router
+@nrwl/react
+@nxtend/capacitor
 @testing-library/user-event
 @testing-library/jest-dom
 @testing-library/cypress

--- a/packages/ionic-react/CHANGELOG.md
+++ b/packages/ionic-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 3.0.4
+
+## Bug Fixes
+
+- fix `Collection @nrwl/react not found` error if `@nrwl/react` is not added manually
+
 # 3.0.3
 
 ## Bug Fixes

--- a/packages/ionic-react/collection.json
+++ b/packages/ionic-react/collection.json
@@ -2,7 +2,6 @@
   "$schema": "../../node_modules/@angular-devkit/schematics/collection-schema.json",
   "name": "IonicReact",
   "version": "0.0.1",
-  "extends": ["@nrwl/react"],
   "schematics": {
     "init": {
       "factory": "./src/schematics/init/schematic",

--- a/packages/ionic-react/package.json
+++ b/packages/ionic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxtend/ionic-react",
-  "version": "3.0.3",
+  "version": "3.0.4-dev",
   "description": "An Nx plugin for developing Ionic React applications and libraries",
   "author": {
     "name": "Devin Shoemaker",
@@ -18,7 +18,5 @@
   "ng-update": {
     "migrations": "./migrations.json"
   },
-  "dependencies": {
-    "@nxtend/capacitor": "*"
-  }
+  "dependencies": {}
 }

--- a/packages/ionic-react/src/schematics/application/schematic.spec.ts
+++ b/packages/ionic-react/src/schematics/application/schematic.spec.ts
@@ -480,6 +480,11 @@ describe('application', () => {
   describe('--capacitor', () => {
     describe('true', () => {
       it('should generate Capacitor project', async () => {
+        const externalSchematicSpy = jest.spyOn(
+          ngSchematics,
+          'externalSchematic'
+        );
+
         const tree = await testRunner
           .runSchematicAsync(
             'application',
@@ -487,6 +492,12 @@ describe('application', () => {
             appTree
           )
           .toPromise();
+
+        expect(externalSchematicSpy).toBeCalledWith(
+          '@nxtend/capacitor',
+          'capacitor-project',
+          expect.objectContaining({})
+        );
 
         testGeneratedFiles(tree, { ...options, capacitor: true });
       });

--- a/packages/ionic-react/src/schematics/application/schematic.ts
+++ b/packages/ionic-react/src/schematics/application/schematic.ts
@@ -17,7 +17,7 @@ export default function (options: ApplicationSchematicSchema): Rule {
   const normalizedOptions = normalizeOptions(options);
 
   return chain([
-    init(options),
+    init(),
     addDependencies(),
     generateNrwlReactApplication(options),
     addFiles(normalizedOptions),

--- a/packages/ionic-react/src/schematics/init/lib/add-capacitor-plugin.ts
+++ b/packages/ionic-react/src/schematics/init/lib/add-capacitor-plugin.ts
@@ -1,32 +1,21 @@
-import {
-  chain,
-  externalSchematic,
-  noop,
-  Rule,
-  Tree,
-} from '@angular-devkit/schematics';
+import { noop, Rule, Tree } from '@angular-devkit/schematics';
 import { addDepsToPackageJson, readJsonInTree } from '@nrwl/workspace';
 import { nxtendCapacitorVersion } from '../../../utils/versions';
-import { InitSchematicSchema } from '../schema';
 
-export function addCapacitorPlugin(options: InitSchematicSchema): Rule {
+export function addCapacitorPlugin(): Rule {
   return (host: Tree) => {
     const packageJson = readJsonInTree(host, 'package.json');
 
     if (
-      options.capacitor &&
       !packageJson.dependencies['@nxtend/capacitor'] &&
       !packageJson.devDependencies['@nxtend/capacitor']
     ) {
-      return chain([
-        addDepsToPackageJson(
-          {},
-          {
-            '@nxtend/capacitor': nxtendCapacitorVersion,
-          }
-        ),
-        externalSchematic('@nxtend/capacitor', 'init', {}),
-      ]);
+      return addDepsToPackageJson(
+        {},
+        {
+          '@nxtend/capacitor': nxtendCapacitorVersion,
+        }
+      );
     } else {
       return noop();
     }

--- a/packages/ionic-react/src/schematics/init/lib/add-react-plugin.ts
+++ b/packages/ionic-react/src/schematics/init/lib/add-react-plugin.ts
@@ -1,10 +1,4 @@
-import {
-  chain,
-  externalSchematic,
-  noop,
-  Rule,
-  Tree,
-} from '@angular-devkit/schematics';
+import { noop, Rule, Tree } from '@angular-devkit/schematics';
 import { addDepsToPackageJson, readJsonInTree } from '@nrwl/workspace';
 
 export function addReactPlugin(): Rule {
@@ -23,15 +17,12 @@ export function addReactPlugin(): Rule {
         throw new Error('@nrwl/workspace is not installed as a dependency.');
       }
 
-      return chain([
-        addDepsToPackageJson(
-          {},
-          {
-            '@nrwl/react': nxVersion,
-          }
-        ),
-        externalSchematic('@nrwl/react', 'init', {}),
-      ]);
+      return addDepsToPackageJson(
+        {},
+        {
+          '@nrwl/react': nxVersion,
+        }
+      );
     } else {
       return noop();
     }

--- a/packages/ionic-react/src/schematics/init/schema.d.ts
+++ b/packages/ionic-react/src/schematics/init/schema.d.ts
@@ -1,3 +1,0 @@
-export interface InitSchematicSchema {
-  capacitor: boolean;
-}

--- a/packages/ionic-react/src/schematics/init/schematic.spec.ts
+++ b/packages/ionic-react/src/schematics/init/schematic.spec.ts
@@ -1,4 +1,3 @@
-import * as ngSchematics from '@angular-devkit/schematics';
 import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { readJsonInTree } from '@nrwl/workspace';
@@ -56,24 +55,18 @@ describe('init', () => {
       .toPromise();
     const packageJson = readJsonInTree(result, 'package.json');
 
+    expect(packageJson.dependencies['@ionic/react']).toBeDefined();
+    expect(packageJson.dependencies['ionicons']).toBeDefined();
+
     expect(packageJson.devDependencies['@nrwl/react']).toBeDefined();
     expect(packageJson.devDependencies['@nrwl/react']).toEqual('0.0.0');
-
-    expect(packageJson.dependencies['react']).toBeDefined();
-    expect(packageJson.dependencies['react-dom']).toBeDefined();
-  });
-
-  it('should add and initialize nxtend Capacitor plugin', async () => {
-    const result = await testRunner
-      .runSchematicAsync('init', { capacitor: true }, appTree)
-      .toPromise();
-    const packageJson = readJsonInTree(result, 'package.json');
-
     expect(packageJson.devDependencies['@nxtend/capacitor']).toBeDefined();
-    expect(packageJson.devDependencies['@nxtend/capacitor']).not.toEqual('*');
-
-    expect(packageJson.dependencies['@capacitor/core']).toBeDefined();
-    expect(packageJson.devDependencies['@capacitor/cli']).toBeDefined();
+    expect(
+      packageJson.devDependencies['@testing-library/jest-dom']
+    ).toBeDefined();
+    expect(
+      packageJson.devDependencies['@testing-library/user-event']
+    ).toBeDefined();
   });
 
   it('should throw an error if Nrwl Workspace plugin is not installed', async () => {
@@ -99,23 +92,5 @@ describe('init', () => {
     const workspaceJson = readJsonInTree(result, 'workspace.json');
 
     expect(workspaceJson.cli.defaultCollection).toEqual('@nxtend/ionic-react');
-  });
-
-  describe('external schematics', () => {
-    it('should call the @nxtend/capacitor:init schematic', async () => {
-      const externalSchematicSpy = jest.spyOn(
-        ngSchematics,
-        'externalSchematic'
-      );
-      await testRunner
-        .runSchematicAsync('init', { capacitor: true }, appTree)
-        .toPromise();
-
-      expect(externalSchematicSpy).toBeCalledWith(
-        '@nxtend/capacitor',
-        'init',
-        expect.objectContaining({})
-      );
-    });
   });
 });

--- a/packages/ionic-react/src/schematics/init/schematic.ts
+++ b/packages/ionic-react/src/schematics/init/schematic.ts
@@ -3,13 +3,12 @@ import { setDefaultCollection } from '@nrwl/workspace/src/utils/rules/workspace'
 import { addCapacitorPlugin } from './lib/add-capacitor-plugin';
 import { addDependencies } from './lib/add-dependencies';
 import { addReactPlugin } from './lib/add-react-plugin';
-import { InitSchematicSchema } from './schema';
 
-export default function (options: InitSchematicSchema): Rule {
+export default function (): Rule {
   return chain([
     setDefaultCollection('@nxtend/ionic-react'),
     addReactPlugin(),
-    addCapacitorPlugin(options),
+    addCapacitorPlugin(),
     addDependencies(),
   ]);
 }


### PR DESCRIPTION
# Description

Due to recent changes, a user would encounter a "collection not found" error if they did not manually add `@nrwl/react` before using the `@nxtend/ionic-react` plugin.

This change now adds a requirement for users to execute the `init` schematic before the `application` schematic, but seems to be the best compromise at the moment.

# PR Checklist

- [ ] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [x] Documentation has been updated if necessary
