### PR TITLE
fix(ionic-react): add "**/*.test.ts" to e2e tsconfig

### DIFF
--- a/e2e/ionic-react-e2e/tsconfig.spec.json
+++ b/e2e/ionic-react-e2e/tsconfig.spec.json
@@ -5,5 +5,5 @@
     "module": "commonjs",
     "types": ["jest", "node"]
   },
-  "include": ["**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.spec.ts", "**/*.test.ts", "**/*.d.ts"]
 }


### PR DESCRIPTION
# Description

This fixes ESLint references to `@nxtend/ionic-react` from `ionic-react-e2e`.

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #227 
