### PR TITLE
chore(ionic-react): upgrade Ionicons app dependency to 5.1.2

### DIFF
--- a/packages/ionic-react/CHANGELOG.md
+++ b/packages/ionic-react/CHANGELOG.md
@@ -3,7 +3,8 @@
 # 3.2.0
 
 - upgrade `@nxtend/capacitor` to 1.1.0
-- upgrade Ionic to 3.2.0
+- upgrade Ionic to 5.3.2
+- upgrade Ionicons to 5.1.2
 
 # 3.1.0
 

--- a/packages/ionic-react/migrations.json
+++ b/packages/ionic-react/migrations.json
@@ -170,6 +170,10 @@
         "@nxtend/capacitor": {
           "version": "1.1.0",
           "alwaysAddToPackageJson": false
+        },
+        "ionicons": {
+          "version": "5.1.2",
+          "alwaysAddToPackageJson": false
         }
       }
     }

--- a/packages/ionic-react/src/migrations/update-3-2-0/update-3-2-0.spec.ts
+++ b/packages/ionic-react/src/migrations/update-3-2-0/update-3-2-0.spec.ts
@@ -20,7 +20,10 @@ describe('Update 3.2.0', () => {
       'package.json',
       serializeJson({
         dependencies: {
+          '@ionic/react': '5.3.1',
+          '@ionic/react-router': '5.3.1',
           '@nxtend/capacitor': '1.0.0',
+          ionicons: '5.0.1',
         },
       })
     );
@@ -32,6 +35,9 @@ describe('Update 3.2.0', () => {
       .toPromise();
 
     const { dependencies } = readJsonInTree(result, '/package.json');
+    expect(dependencies['@ionic/react']).toEqual('5.3.2');
+    expect(dependencies['@ionic/react-router']).toEqual('5.3.2');
     expect(dependencies['@nxtend/capacitor']).toEqual('1.1.0');
+    expect(dependencies['ionicons']).toEqual('5.1.2');
   });
 });

--- a/packages/ionic-react/src/utils/versions.ts
+++ b/packages/ionic-react/src/utils/versions.ts
@@ -2,7 +2,7 @@ export const nxtendCapacitorVersion = '1.1.0';
 
 export const ionicReactVersion = '5.3.2';
 export const ionicReactRouterVersion = '5.3.2';
-export const ioniconsVersion = '5.0.1';
+export const ioniconsVersion = '5.1.2';
 
 export const testingLibraryJestDomVersion = '5.11.0';
 export const testingLibraryUserEventVersion = '12.0.11';


### PR DESCRIPTION
# Description

Upgrade Ionicons to 5.1.2 in application schematic

# PR Checklist

- [x] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #233 

