### PR TITLE
chore(capacitor): e2e test with @nrwl/react app

### DIFF
--- a/e2e/capacitor-e2e/tests/capacitor-project.test.ts
+++ b/e2e/capacitor-e2e/tests/capacitor-project.test.ts
@@ -1,21 +1,27 @@
 import {
   checkFilesExist,
   ensureNxProject,
-  patchPackageJsonForPlugin,
+  readFile,
   runNxCommandAsync,
   runYarnInstall,
   uniq,
+  updateFile,
 } from '@nrwl/nx-plugin/testing';
 
 describe('capacitor-project e2e', () => {
   const asyncTimeout = 150000;
 
   async function generateApp(plugin: string) {
-    ensureNxProject('@nxtend/ionic-react', 'dist/packages/ionic-react');
-    patchPackageJsonForPlugin('@nxtend/capacitor', 'dist/packages/capacitor');
+    ensureNxProject('@nxtend/capacitor', 'dist/packages/capacitor');
+
+    const packageJson = JSON.parse(readFile('package.json'));
+    packageJson.devDependencies['@nrwl/react'] = '*';
+    updateFile('package.json', JSON.stringify(packageJson));
     runYarnInstall();
+
+    await runNxCommandAsync(`generate @nrwl/react:app ${plugin}`);
     await runNxCommandAsync(
-      `generate @nxtend/ionic-react:app ${plugin} --capacitor true`
+      `generate @nxtend/capacitor:capacitor-project ${plugin}-cap --project ${plugin}`
     );
   }
 


### PR DESCRIPTION
# Description

Previously this test was generating an @nxtend/ionic-react application in order to test @nxtend/capacitor. This created an unnecessary implicit dependency between the @nxtend/capacitor e2e tests and @nxtend/ionic-react. This new approach uses @nrwl/react to generate the application which removes that implicit dependency.

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [x] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #
