### PR TITLE
feat(capacitor): add `packageInstall` option to `cap` builder

### DIFF
--- a/apps/docs/docs/capacitor/builders/cap.md
+++ b/apps/docs/docs/capacitor/builders/cap.md
@@ -24,7 +24,8 @@ Runs a builder that executes a Capacitor command.
     "copy": {
       "builder": "@nxtend/capacitor:cap",
       "options": {
-        "cmd": "copy"
+        "cmd": "copy",
+        "packageInstall": false
       },
       "configurations": {
         "ios": {
@@ -55,3 +56,11 @@ Default: `null`
 Type: `string`
 
 The Capacitor command.
+
+### --packageInstall
+
+Default: `undefined`
+
+Type: `boolean`
+
+Whether or not to install dependencies in the application directory.

--- a/e2e/capacitor-e2e/tests/capacitor.test.ts
+++ b/e2e/capacitor-e2e/tests/capacitor.test.ts
@@ -52,7 +52,12 @@ async function buildAndTestApp(plugin: string) {
   expect(e2eResults.stdout).toContain('All specs passed!');
 
   const capResults = await runNxCommandAsync(`run ${plugin}:cap`);
-  expect(capResults.stdout).toContain('Usage: cap');
+  expect(capResults.stdout).toContain('success');
+
+  const capPackageInstallResults = await runNxCommandAsync(
+    `run ${plugin}:cap --packageInstall false`
+  );
+  expect(capPackageInstallResults.stdout).toContain('Usage: cap');
 }
 
 describe('capacitor-project e2e', () => {

--- a/packages/capacitor/src/builders/cap/builder.ts
+++ b/packages/capacitor/src/builders/cap/builder.ts
@@ -24,17 +24,28 @@ export function runBuilder(
           .toString()
       );
 
-      return context.scheduleBuilder('@nrwl/workspace:run-commands', {
-        cwd: frontendProjectRoot,
-        parallel: false,
-        commands: [
+      let commands = [
+        {
+          command: `npx cap ${options.cmd}`,
+        },
+      ];
+
+      if (
+        options.packageInstall === true ||
+        options.packageInstall === undefined
+      ) {
+        commands = [
           {
             command: `${capacitorConfigJson.npmClient} install`,
           },
-          {
-            command: `npx cap ${options.cmd}`,
-          },
-        ],
+          ...commands,
+        ];
+      }
+
+      return context.scheduleBuilder('@nrwl/workspace:run-commands', {
+        cwd: frontendProjectRoot,
+        parallel: false,
+        commands,
       });
     }),
     switchMap((run) => run.output)

--- a/packages/capacitor/src/builders/cap/schema.d.ts
+++ b/packages/capacitor/src/builders/cap/schema.d.ts
@@ -2,4 +2,5 @@ import { JsonObject } from '@angular-devkit/core';
 
 export interface CommandBuilderSchema extends JsonObject {
   cmd: string;
+  packageInstall: boolean | undefined;
 }

--- a/packages/capacitor/src/builders/cap/schema.json
+++ b/packages/capacitor/src/builders/cap/schema.json
@@ -7,6 +7,10 @@
     "cmd": {
       "description": "The Capacitor command.",
       "type": "string"
+    },
+    "packageInstall": {
+      "description": "Whether or not to install dependencies in the application directory.",
+      "type": "boolean"
     }
   },
   "required": []

--- a/packages/capacitor/src/migrations/update-11-0-0/update-workspace-json-11-0-0.spec.ts
+++ b/packages/capacitor/src/migrations/update-11-0-0/update-workspace-json-11-0-0.spec.ts
@@ -37,6 +37,36 @@ describe('Update 2.0.0', () => {
                   },
                 },
               },
+              copy: {
+                builder: '@nxtend/capacitor:command',
+                options: {
+                  command: 'copy',
+                  platform: '',
+                },
+                configurations: {
+                  ios: {
+                    platform: 'ios',
+                  },
+                  android: {
+                    platform: 'android',
+                  },
+                },
+              },
+              update: {
+                builder: '@nxtend/capacitor:command',
+                options: {
+                  command: 'update',
+                  platform: '',
+                },
+                configurations: {
+                  ios: {
+                    platform: 'ios',
+                  },
+                  android: {
+                    platform: 'android',
+                  },
+                },
+              },
             },
           },
           ['my-app-2']: {
@@ -68,12 +98,19 @@ describe('Update 2.0.0', () => {
     expect(
       workspaceJson.projects['my-app-1'].architect['cap'].options.cmd
     ).toEqual('--help');
+    expect(
+      workspaceJson.projects['my-app-1'].architect['cap'].options.packageInstall
+    ).toEqual(true);
+
     expect(workspaceJson.projects['my-app-1'].architect['add'].builder).toEqual(
       '@nxtend/capacitor:cap'
     );
     expect(
       workspaceJson.projects['my-app-1'].architect['add'].options.cmd
     ).toEqual('add');
+    expect(
+      workspaceJson.projects['my-app-1'].architect['add'].options.packageInstall
+    ).toEqual(true);
     expect(
       workspaceJson.projects['my-app-1'].architect['add'].configurations['ios']
         .cmd
@@ -84,12 +121,54 @@ describe('Update 2.0.0', () => {
       ].cmd
     ).toEqual('add android');
 
+    expect(workspaceJson.projects['my-app-1'].architect['add'].builder).toEqual(
+      '@nxtend/capacitor:cap'
+    );
+    expect(
+      workspaceJson.projects['my-app-1'].architect['copy'].options.cmd
+    ).toEqual('copy');
+    expect(
+      workspaceJson.projects['my-app-1'].architect['copy'].options
+        .packageInstall
+    ).toEqual(false);
+    expect(
+      workspaceJson.projects['my-app-1'].architect['copy'].configurations['ios']
+        .cmd
+    ).toEqual('copy ios');
+    expect(
+      workspaceJson.projects['my-app-1'].architect['copy'].configurations[
+        'android'
+      ].cmd
+    ).toEqual('copy android');
+
+    expect(
+      workspaceJson.projects['my-app-1'].architect['update'].builder
+    ).toEqual('@nxtend/capacitor:cap');
+    expect(
+      workspaceJson.projects['my-app-1'].architect['update'].options.cmd
+    ).toEqual('update');
+    expect(
+      workspaceJson.projects['my-app-1'].architect['update'].options
+        .packageInstall
+    ).toEqual(true);
+    expect(
+      workspaceJson.projects['my-app-1'].architect['update'].configurations[
+        'ios'
+      ].cmd
+    ).toEqual('update ios');
+    expect(
+      workspaceJson.projects['my-app-1'].architect['update'].configurations[
+        'android'
+      ].cmd
+    ).toEqual('update android');
+
     expect(workspaceJson.projects['my-app-2'].architect['cap'].builder).toEqual(
       '@nxtend/capacitor:cap'
     );
     expect(
       workspaceJson.projects['my-app-2'].architect['cap'].options.cmd
     ).toEqual('--help');
+
     expect(workspaceJson.projects['my-app-2'].architect['add'].builder).toEqual(
       '@nxtend/capacitor:cap'
     );

--- a/packages/capacitor/src/migrations/update-11-0-0/update-workspace-json-11-0-0.ts
+++ b/packages/capacitor/src/migrations/update-11-0-0/update-workspace-json-11-0-0.ts
@@ -17,8 +17,15 @@ function updateCapacitorBuilder() {
         isProjectCapacitor = true;
 
         target.builder = '@nxtend/capacitor:cap';
+
+        const packageInstall =
+          target.options.command === 'add' ||
+          target.options.command === 'update' ||
+          target.options.command === 'sync';
+
         target.options = {
           cmd: target.options.command,
+          packageInstall,
         };
 
         if (!target.configurations) {
@@ -39,6 +46,7 @@ function updateCapacitorBuilder() {
           builder: '@nxtend/capacitor:cap',
           options: {
             cmd: '--help',
+            packageInstall: true,
           },
         };
       }

--- a/packages/capacitor/src/schematics/capacitor-project/lib/add-project.ts
+++ b/packages/capacitor/src/schematics/capacitor-project/lib/add-project.ts
@@ -17,10 +17,14 @@ export function addProject(options: NormalizedSchema) {
     let command: string, platform: string;
 
     for (command of commands) {
+      const packageInstall =
+        command === 'add' || command === 'update' || command === 'sync';
+
       architect[command] = {
         builder: `@nxtend/capacitor:cap`,
         options: {
           cmd: `${command}`,
+          packageInstall,
         },
         configurations: {},
       };

--- a/packages/capacitor/src/schematics/capacitor-project/schematic.spec.ts
+++ b/packages/capacitor/src/schematics/capacitor-project/schematic.spec.ts
@@ -91,6 +91,7 @@ describe('capacitor-project', () => {
       workspaceJson.projects[options.project].architect.add.options
     ).toEqual({
       cmd: 'add',
+      packageInstall: true,
     });
     expect(
       workspaceJson.projects[options.project].architect.add.configurations[
@@ -110,6 +111,7 @@ describe('capacitor-project', () => {
       workspaceJson.projects[options.project].architect.copy.options
     ).toEqual({
       cmd: 'copy',
+      packageInstall: false,
     });
     expect(
       workspaceJson.projects[options.project].architect.copy.configurations[
@@ -129,6 +131,7 @@ describe('capacitor-project', () => {
       workspaceJson.projects[options.project].architect.open.options
     ).toEqual({
       cmd: 'open',
+      packageInstall: false,
     });
     expect(
       workspaceJson.projects[options.project].architect.open.configurations[
@@ -148,6 +151,7 @@ describe('capacitor-project', () => {
       workspaceJson.projects[options.project].architect.sync.options
     ).toEqual({
       cmd: 'sync',
+      packageInstall: true,
     });
     expect(
       workspaceJson.projects[options.project].architect.sync.configurations[
@@ -167,6 +171,7 @@ describe('capacitor-project', () => {
       workspaceJson.projects[options.project].architect.update.options
     ).toEqual({
       cmd: 'update',
+      packageInstall: true,
     });
     expect(
       workspaceJson.projects[options.project].architect.update.configurations[


### PR DESCRIPTION
# Description

Add a boolean option to the Capacitor `command` builder to determine if the builder should install Node packages before running the desired command. If the option is not specified then the package install will run by default for backwards compatibility.

# PR Checklist

- [x] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [x] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [x] Documentation has been updated if necessary

# Issue

Resolves #
