### PR TITLE
Patch only valid configurations with existing platform

### DIFF
--- a/packages/capacitor/src/migrations/update-11-0-0/update-workspace-json-11-0-0.ts
+++ b/packages/capacitor/src/migrations/update-11-0-0/update-workspace-json-11-0-0.ts
@@ -32,7 +32,9 @@ function updateCapacitorBuilder() {
           return;
         }
 
-        Object.values<any>(target.configurations).forEach(
+        Object.values<any>(target.configurations)
+          .filter((configuration: any) => configuration.platform !== undefined)
+          .forEach(
           (configuration: any) => {
             const platform = configuration.platform;
             configuration.cmd = `${target.options.cmd} ${platform}`;


### PR DESCRIPTION
# Description
Solves problem when a command contains configurations that is not object and / or doesn't have platform key
# PR Checklist

- [x ] Migrations have been added if necessary

# Issue
https://github.com/nxtend-team/nxtend/issues/388
Resolves #
https://github.com/nxtend-team/nxtend/issues/388
