### PR TITLE
fix(capacitor): fix migration for angular.json users

### DIFF
--- a/packages/capacitor/src/migrations/update-11-0-0/update-workspace-json-11-0-0.ts
+++ b/packages/capacitor/src/migrations/update-11-0-0/update-workspace-json-11-0-0.ts
@@ -1,12 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { chain, Rule, Tree } from '@angular-devkit/schematics';
-import { readJsonInTree } from '@nrwl/workspace';
+import { chain, Rule } from '@angular-devkit/schematics';
+import { updateWorkspaceInTree } from '@nrwl/workspace';
 
 function updateCapacitorBuilder() {
-  return (host: Tree) => {
-    const workspaceJson = readJsonInTree(host, 'workspace.json');
-
-    Object.values<any>(workspaceJson.projects).forEach((project) => {
+  return updateWorkspaceInTree((json) => {
+    Object.values<any>(json.projects).forEach((project) => {
       let isProjectCapacitor = false;
 
       Object.values<any>(project.architect).forEach((target) => {
@@ -56,8 +54,8 @@ function updateCapacitorBuilder() {
       }
     });
 
-    host.overwrite('workspace.json', JSON.stringify(workspaceJson));
-  };
+    return json;
+  });
 }
 
 export default function update(): Rule {


### PR DESCRIPTION
# Description

The 11.0.0 migration for Capacitor did not work for `angular.json` users. This update accounts for both `angular.json` and `workspace.json` users.

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #397 
