### PR TITLE
feat(ionic-angular): enable Jest for Ionic Angular apps

### DIFF
--- a/apps/docs/docs/ionic-angular/schematics/application.md
+++ b/apps/docs/docs/ionic-angular/schematics/application.md
@@ -28,11 +28,11 @@ The subdirectory of the new application. By default, apps will be generated unde
 
 ### ---unitTestRunner
 
-Default: `karma`
+Default: `jest`
 
 Type: `string`
 
-Possible values: `karma`, `none`
+Possible values: `jest`, `karma`, `none`
 
 Test runner to use for unit tests.
 

--- a/e2e/ionic-angular-e2e/tests/ionic-angular.test.ts
+++ b/e2e/ionic-angular-e2e/tests/ionic-angular.test.ts
@@ -19,7 +19,7 @@ describe('Ionic Angular Application', () => {
 
     if (unitTestRunner === 'jest') {
       const testResults = await runNxCommandAsync(`test ${plugin}`);
-      expect(testResults.stdout).toContain('Done in');
+      expect(testResults.stderr).not.toContain(/fail/i);
     }
     if (unitTestRunner === 'karma') {
       const testResults = await runNxCommandAsync(

--- a/e2e/ionic-angular-e2e/tests/ionic-angular.test.ts
+++ b/e2e/ionic-angular-e2e/tests/ionic-angular.test.ts
@@ -7,17 +7,26 @@ import {
 describe('Ionic Angular Application', () => {
   const asyncTimeout = 300000;
 
-  async function buildAndTestApp(plugin: string) {
+  async function buildAndTestApp(
+    plugin: string,
+    unitTestRunner: 'jest' | 'karma' | 'none' = 'jest'
+  ) {
     const buildResults = await runNxCommandAsync(`build ${plugin}`);
     expect(buildResults.stdout).not.toContain('ERROR');
 
     const lintResults = await runNxCommandAsync(`lint ${plugin}`);
     expect(lintResults.stdout).not.toContain('ERROR');
 
-    const testResults = await runNxCommandAsync(
-      `test ${plugin} --browsers ChromeHeadless --watch false`
-    );
-    expect(testResults.stdout).toContain('SUCCESS');
+    if (unitTestRunner === 'jest') {
+      const testResults = await runNxCommandAsync(`test ${plugin}`);
+      expect(testResults.stdout).toContain('Done in');
+    }
+    if (unitTestRunner === 'karma') {
+      const testResults = await runNxCommandAsync(
+        `test ${plugin} --browsers ChromeHeadless --watch false`
+      );
+      expect(testResults.stdout).toContain('SUCCESS');
+    }
 
     const e2eResults = await runNxCommandAsync(`e2e ${plugin}-e2e --headless`);
     expect(e2eResults.stdout).toContain('All specs passed!');
@@ -132,6 +141,36 @@ describe('Ionic Angular Application', () => {
 
       await buildAndTestApp(appName);
 
+      done();
+    },
+    asyncTimeout
+  );
+
+  it(
+    'should create with unitTestRunner=none',
+    async (done) => {
+      const appName = uniq('ionic-angular');
+      ensureNxProject('@nxtend/ionic-angular', 'dist/packages/ionic-angular');
+      await runNxCommandAsync(
+        `generate @nxtend/ionic-angular:app --name ${appName} --capacitor false --unitTestRunner none`
+      );
+
+      await buildAndTestApp(appName, 'none');
+      done();
+    },
+    asyncTimeout
+  );
+
+  it(
+    'should create with unitTestRunner=karma',
+    async (done) => {
+      const appName = uniq('ionic-angular');
+      ensureNxProject('@nxtend/ionic-angular', 'dist/packages/ionic-angular');
+      await runNxCommandAsync(
+        `generate @nxtend/ionic-angular:app --name ${appName} --capacitor false --unitTestRunner karma`
+      );
+
+      await buildAndTestApp(appName, 'karma');
       done();
     },
     asyncTimeout

--- a/packages/ionic-angular/CHANGELOG.md
+++ b/packages/ionic-angular/CHANGELOG.md
@@ -7,6 +7,7 @@
 - update application starter templates
 - support ESLint when generating applications
 - generate applications with ESLint by default instead of TSLint
+- support `jest` as a unit test config for the application schematic
 
 # 11.0.2
 

--- a/packages/ionic-angular/src/schematics/application/files/list/src/app/home/home.page.spec.ts.template
+++ b/packages/ionic-angular/src/schematics/application/files/list/src/app/home/home.page.spec.ts.template
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
-import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { MessageComponentModule } from '../message/message.module';
 
 import { HomePage } from './home.page';
@@ -12,7 +12,7 @@ describe('HomePage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ HomePage ],
-      imports: [IonicModule.forRoot(), MessageComponentModule, RouterModule.forRoot([])]
+      imports: [IonicModule.forRoot(), MessageComponentModule, RouterTestingModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomePage);

--- a/packages/ionic-angular/src/schematics/application/files/list/src/app/message/message.component.spec.ts.template
+++ b/packages/ionic-angular/src/schematics/application/files/list/src/app/message/message.component.spec.ts.template
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
-import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { MessageComponent } from './message.component';
 
@@ -11,7 +11,7 @@ describe('MessageComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ MessageComponent ],
-      imports: [IonicModule.forRoot(), RouterModule.forRoot([])]
+      imports: [IonicModule.forRoot(), RouterTestingModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(MessageComponent);

--- a/packages/ionic-angular/src/schematics/application/files/list/src/app/view-message/view-message.page.spec.ts.template
+++ b/packages/ionic-angular/src/schematics/application/files/list/src/app/view-message/view-message.page.spec.ts.template
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
-import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ViewMessagePageRoutingModule } from './view-message-routing.module';
 
 import { ViewMessagePage } from './view-message.page';
@@ -12,7 +12,7 @@ describe('ViewMessagePage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ ViewMessagePage ],
-      imports: [IonicModule.forRoot(), ViewMessagePageRoutingModule, RouterModule.forRoot([])]
+      imports: [IonicModule.forRoot(), ViewMessagePageRoutingModule, RouterTestingModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ViewMessagePage);

--- a/packages/ionic-angular/src/schematics/application/files/sidemenu/src/app/folder/folder.page.spec.ts.template
+++ b/packages/ionic-angular/src/schematics/application/files/sidemenu/src/app/folder/folder.page.spec.ts.template
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
-import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { FolderPage } from './folder.page';
 
 describe('FolderPage', () => {
@@ -10,7 +10,7 @@ describe('FolderPage', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ FolderPage ],
-      imports: [IonicModule.forRoot(), RouterModule.forRoot([])]
+      imports: [IonicModule.forRoot(), RouterTestingModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(FolderPage);

--- a/packages/ionic-angular/src/schematics/application/schema.d.ts
+++ b/packages/ionic-angular/src/schematics/application/schema.d.ts
@@ -1,7 +1,7 @@
 export interface ApplicationSchematicSchema {
   name: string;
   directory?: string;
-  unitTestRunner: 'karma' | 'none';
+  unitTestRunner: 'jest' | 'karma' | 'none';
   e2eTestRunner: 'cypress' | 'none';
   tags?: string;
   linter: 'eslint' | 'tslint';

--- a/packages/ionic-angular/src/schematics/application/schema.json
+++ b/packages/ionic-angular/src/schematics/application/schema.json
@@ -21,9 +21,9 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["karma", "none"],
+      "enum": ["jest", "karma", "none"],
       "description": "Test runner to use for unit tests.",
-      "default": "karma"
+      "default": "jest"
     },
     "e2eTestRunner": {
       "type": "string",

--- a/packages/ionic-angular/src/schematics/application/schematic.spec.ts
+++ b/packages/ionic-angular/src/schematics/application/schematic.spec.ts
@@ -10,7 +10,7 @@ describe('application schematic', () => {
   const options: ApplicationSchematicSchema = {
     name: 'my-app',
     template: 'blank',
-    unitTestRunner: 'karma',
+    unitTestRunner: 'jest',
     e2eTestRunner: 'cypress',
     linter: 'eslint',
     capacitor: false,
@@ -293,9 +293,43 @@ describe('application schematic', () => {
         )
         .toPromise();
 
+      expect(tree.readContent(`package.json`).includes('jest')).toBeFalsy();
+      expect(tree.readContent(`package.json`).includes('karma')).toBeFalsy();
       expect(
         tree.exists(`${projectRoot}/src/app/home/home.page.spec.ts`)
       ).toBeFalsy();
+    });
+
+    it('jest', async () => {
+      const tree = await testRunner
+        .runSchematicAsync(
+          'application',
+          { ...options, unitTestRunner: 'jest' },
+          appTree
+        )
+        .toPromise();
+
+      expect(tree.readContent(`package.json`).includes('jest')).toBeTruthy();
+      expect(tree.readContent(`package.json`).includes('karma')).toBeFalsy();
+      expect(
+        tree.exists(`${projectRoot}/src/app/home/home.page.spec.ts`)
+      ).toBeTruthy();
+    });
+
+    it('karma', async () => {
+      const tree = await testRunner
+        .runSchematicAsync(
+          'application',
+          { ...options, unitTestRunner: 'karma' },
+          appTree
+        )
+        .toPromise();
+
+      expect(tree.readContent(`package.json`).includes('jest')).toBeFalsy();
+      expect(tree.readContent(`package.json`).includes('karma')).toBeTruthy();
+      expect(
+        tree.exists(`${projectRoot}/src/app/home/home.page.spec.ts`)
+      ).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
# Description

While integrating `@nxtend/ionic-angular` [into nxpm-stack](https://github.com/nxpm/stack/pull/134) I saw it used Karma by default. The rest of the stack uses Jest so I'd love to keep that as the standard.

As these options get passed through to Nx directly, I figured this patch should be enough to create a config similar to the one that's used by `@nrwl/angular` by default.

Let me know if I missed something.

# PR Checklist

Didn't update any tests as it's a pass-through, the tests do run locally though.

- [ ] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [x] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [x] Documentation has been updated if necessary

# Issue

Resolves #333 


For now I'm using `none` to not add Karma config/deps as suggested in the issue above, but the downside of this is that it changes the config for the new libs/components/etc that get generated

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/36491/109598583-8574f200-7ae7-11eb-917f-ea79705ec8df.png">
