### PR TITLE
fix: make sure properties can be accessed safely

### DIFF
--- a/packages/ionic-angular/src/schematics/application/lib/update-eslint-config.ts
+++ b/packages/ionic-angular/src/schematics/application/lib/update-eslint-config.ts
@@ -10,11 +10,11 @@ export function updateEslintConfig(options: NormalizedSchema) {
   return updateJsonInTree(
     `${options.appProjectRoot}/.eslintrc.json`,
     (json) => {
-      console.log(json);
-      const tsOverride = json.overrides.find(
-        (override: { files: string | string[] }) =>
+      const tsOverride =
+        json.overrides?.find((override: { files: string | string[] }) =>
           override.files.includes('*.ts')
-      );
+        ) || {};
+      tsOverride.rules = tsOverride?.rules || {};
       tsOverride.rules['@angular-eslint/component-class-suffix'] = [
         'error',
         {


### PR DESCRIPTION
# Description

I was getting some issues while running the latest version in my unit tests:

```
TypeError: Cannot read property 'find' of undefined

at ../ionic-angular/src/schematics/application/lib/update-eslint-config.ts:14:41
```
and after fixing that:

```
 TypeError: Cannot read property 'rules' of undefined
```

If figured it would be good to add some safety guards here.

I'm not sure how to test this in the project - very open for suggestions if you have any!

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #
