### PR TITLE
chore(capacitor): remove Capacitor 3 migration

### DIFF
--- a/packages/capacitor/migrations.json
+++ b/packages/capacitor/migrations.json
@@ -26,6 +26,14 @@
       "factory": "./src/migrations/update-11-0-0/update-11-0-0"
     }
   },
+  "generators": {
+    "capacitor-3-migration-12-0-0": {
+      "version": "12.0.0-beta.0",
+      "description": "Display Capacitor 3 migration guide.",
+      "cli": "nx",
+      "implementation": "./src/migrations/update-12-0-0/capacitor-3-migration-12-0-0"
+    }
+  },
   "packageJsonUpdates": {
     "1.1.0": {
       "version": "1.1.0-beta.1",

--- a/packages/capacitor/src/migrations/update-12-0-0/capacitor-3-migration-12-0-0.ts
+++ b/packages/capacitor/src/migrations/update-12-0-0/capacitor-3-migration-12-0-0.ts
@@ -1,0 +1,10 @@
+import { logger, stripIndents } from '@nrwl/devkit';
+
+export default function update() {
+  logger.info(stripIndents`
+    Capacitor 3 has been released and it is recommended that you upgrade your application if you have not already.
+    You will need to upgrade before using the new run command.
+    
+    https://capacitorjs.com/docs/updating/3-0
+    `);
+}


### PR DESCRIPTION
This would have likely break Capacitor 2 applications, so instead of automatically updating these dependencies, we will display a message to user with instructions on how to migrate to Capacitor 3.

# Description

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #535
