### PR TITLE
Nx ng 13

### DIFF
--- a/packages/capacitor/CHANGELOG.md
+++ b/packages/capacitor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 12.0.0-beta.2
+
+## Features
+
+- support Nx 13
+
+## Bug Fixes
+
+- Fixes expected $id instead of id when running generators
+
 # 12.0.0
 
 ## Features

--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxtend/capacitor",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "description": "An Nx plugin for developing cross-platform applications using Capacitor",
   "author": {
     "name": "Devin Shoemaker",
@@ -19,7 +19,7 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@nrwl/devkit": "^12.0.0",
-    "@nrwl/workspace": "^12.0.0"
+    "@nrwl/devkit": "^13.0.0",
+    "@nrwl/workspace": "^13.0.0"
   }
 }

--- a/packages/capacitor/src/generators/capacitor-project/schema.json
+++ b/packages/capacitor/src/generators/capacitor-project/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
-  "id": "CapacitorProject",
+  "$id": "CapacitorProject",
   "title": "Create a Capacitor project for an Nx application",
   "type": "object",
   "properties": {

--- a/packages/ionic-angular/CHANGELOG.md
+++ b/packages/ionic-angular/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 12.0.0-beta.2
+
+## Features
+
+- support Nx 13
+
+## Bug Fixes
+
+- Fixes expected $id instead of id when running generators
+
 # 12.0.0
 
 ## Features

--- a/packages/ionic-angular/package.json
+++ b/packages/ionic-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxtend/ionic-angular",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "description": "An Nx plugin for developing Ionic React applications and libraries",
   "author": {
     "name": "Devin Shoemaker",
@@ -19,7 +19,7 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@nrwl/angular": "^12.0.0",
-    "@nxtend/capacitor": "^12.0.0-beta.1"
+    "@nrwl/angular": "^13.0.0",
+    "@nxtend/capacitor": "^12.0.0-beta.2"
   }
 }

--- a/packages/ionic-angular/src/generators/application/generator.spec.ts
+++ b/packages/ionic-angular/src/generators/application/generator.spec.ts
@@ -25,7 +25,7 @@ describe('application schematic', () => {
 
     const packageJson = readJson(appTree, 'package.json');
     expect(packageJson.dependencies['@ionic/angular']).toBeDefined();
-    expect(packageJson.devDependencies['@nrwl/react']).toBeDefined();
+    expect(packageJson.devDependencies['@nrwl/angular']).toBeDefined();
     expect(packageJson.devDependencies['@nxtend/capacitor']).toBeDefined();
   });
 

--- a/packages/ionic-angular/src/generators/application/lib/add-dependencies.ts
+++ b/packages/ionic-angular/src/generators/application/lib/add-dependencies.ts
@@ -11,6 +11,6 @@ export function addDependencies(host: Tree) {
     {
       '@ionic/angular': ionicAngularVersion,
     },
-    { '@nrwl/react': nxVersion, '@nxtend/capacitor': nxtendCapacitorVersion }
+    { '@nrwl/angular': nxVersion, '@nxtend/capacitor': nxtendCapacitorVersion }
   );
 }

--- a/packages/ionic-angular/src/generators/application/schema.json
+++ b/packages/ionic-angular/src/generators/application/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
-  "id": "IonicAngularApp",
+  "$id": "IonicAngularApp",
   "title": "Create an Ionic Angular Application for Nx",
   "type": "object",
   "properties": {

--- a/packages/ionic-angular/src/utils/versions.ts
+++ b/packages/ionic-angular/src/utils/versions.ts
@@ -1,3 +1,3 @@
-export const nxVersion = '^12.0.0';
+export const nxVersion = '^13.0.0';
 export const nxtendCapacitorVersion = '^12.0.0-beta.1';
 export const ionicAngularVersion = '^5.8.3';

--- a/packages/ionic-angular/src/utils/versions.ts
+++ b/packages/ionic-angular/src/utils/versions.ts
@@ -1,3 +1,3 @@
 export const nxVersion = '^13.0.0';
-export const nxtendCapacitorVersion = '^12.0.0-beta.1';
+export const nxtendCapacitorVersion = '^12.0.0-beta.2';
 export const ionicAngularVersion = '^5.8.3';

--- a/packages/ionic-react/CHANGELOG.md
+++ b/packages/ionic-react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+# 12.0.0-beta.2
+
+## Features
+
+- support Nx 13
+
+## Bug Fixes
+
+- Fixes expected $id instead of id when running generators
+
 # 12.0.0
 
 ## Features

--- a/packages/ionic-react/package.json
+++ b/packages/ionic-react/package.json
@@ -19,9 +19,9 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@nrwl/devkit": "^12.0.0",
-    "@nrwl/linter": "^12.0.0",
-    "@nrwl/react": "^12.0.0",
-    "@nxtend/capacitor": "^12.0.0-beta.1"
+    "@nrwl/devkit": "^13.0.0",
+    "@nrwl/linter": "^13.0.0",
+    "@nrwl/react": "^13.0.0",
+    "@nxtend/capacitor": "^12.0.0-beta.2"
   }
 }

--- a/packages/ionic-react/src/generators/application/schema.json
+++ b/packages/ionic-react/src/generators/application/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
-  "id": "Application",
+  "$id": "Application",
   "title": "Create an Ionic React Application for Nx",
   "examples": [
     {

--- a/packages/ionic-react/src/utils/versions.ts
+++ b/packages/ionic-react/src/utils/versions.ts
@@ -1,5 +1,5 @@
-export const nxVersion = '^12.0.0';
-export const nxtendCapacitorVersion = '^12.0.0-beta.1';
+export const nxVersion = '^13.0.0';
+export const nxtendCapacitorVersion = '^12.0.0-beta.2';
 export const ionicReactVersion = '^5.8.3';
 export const ionicReactRouterVersion = '^5.8.3';
 export const ioniconsVersion = '^5.5.3';


### PR DESCRIPTION
# Description

Initial PR that adds support for Nx v13.

Nx v13.2 is RC right now, and that adds support for Angular v13; we can update it as soon as it gets released.

# PR Checklist

- [X] Changelog has been updated if necessary

# Issue

Resolves #540 
