### PR TITLE
feat(ionic-angular): add page generator

### DIFF
--- a/apps/docs/docs/ionic-angular/generators/page.md
+++ b/apps/docs/docs/ionic-angular/generators/page.md
@@ -1,0 +1,25 @@
+---
+id: page
+title: Page
+sidebar_label: Page
+---
+
+Create a page in an existing Ionic Angular app.
+
+## Usage
+
+```
+nx generate @nxtend/ionic-angular:page --name MyPage --project myApp
+```
+
+## Options
+
+### --directory
+
+Alias(es): d
+
+Default: `null`
+
+Type: `string`
+
+The subdirectory of the new page relative to the `app` folder

--- a/e2e/ionic-angular-e2e/tests/ionic-angular.spec.ts
+++ b/e2e/ionic-angular-e2e/tests/ionic-angular.spec.ts
@@ -192,34 +192,48 @@ describe('Ionic Angular Application', () => {
   );
 
   describe('Ionic Angular Page', () => {
-    it('should create page in project', async () => {
-      const appName = uniq('ionic-angular');
-      ensureNxProject('@nxtend/ionic-angular', 'dist/packages/ionic-angular');
-      await runCommandAsync('yarn add -D @nxtend/capacitor');
-      await runNxCommandAsync(
-        `generate @nxtend/ionic-angular:app --name ${appName} --capacitor false`
-      );
-      await runNxCommandAsync(
-        `generate @nxtend/ionic-angular:page --name my-page --project ${appName}`
-      );
-
-      await buildAndTestApp(appName);
-    });
-
-    describe('--directory', () => {
-      it('should create page in directory', async () => {
+    it(
+      'should create page in project',
+      async () => {
         const appName = uniq('ionic-angular');
-        ensureNxProject('@nxtend/ionic-angular', 'dist/packages/ionic-angular');
-        await runCommandAsync('yarn add -D @nxtend/capacitor');
+        ensureNxProjectWithDeps(
+          '@nxtend/ionic-angular',
+          'dist/packages/ionic-angular',
+          [['@nxtend/capacitor', 'dist/packages/capacitor']]
+        );
         await runNxCommandAsync(
           `generate @nxtend/ionic-angular:app --name ${appName} --capacitor false`
         );
         await runNxCommandAsync(
-          `generate @nxtend/ionic-angular:page --name my-page --project ${appName} --directory my-dir`
+          `generate @nxtend/ionic-angular:page --name my-page --project ${appName}`
         );
 
         await buildAndTestApp(appName);
-      });
+      },
+      asyncTimeout
+    );
+
+    describe('--directory', () => {
+      it(
+        'should create page in directory',
+        async () => {
+          const appName = uniq('ionic-angular');
+          ensureNxProjectWithDeps(
+            '@nxtend/ionic-angular',
+            'dist/packages/ionic-angular',
+            [['@nxtend/capacitor', 'dist/packages/capacitor']]
+          );
+          await runNxCommandAsync(
+            `generate @nxtend/ionic-angular:app --name ${appName} --capacitor false`
+          );
+          await runNxCommandAsync(
+            `generate @nxtend/ionic-angular:page --name my-page --project ${appName} --directory my-dir`
+          );
+
+          await buildAndTestApp(appName);
+        },
+        asyncTimeout
+      );
     });
   });
 });

--- a/e2e/ionic-angular-e2e/tests/ionic-angular.spec.ts
+++ b/e2e/ionic-angular-e2e/tests/ionic-angular.spec.ts
@@ -190,4 +190,36 @@ describe('Ionic Angular Application', () => {
     },
     asyncTimeout
   );
+
+  describe('Ionic Angular Page', () => {
+    it('should create page in project', async () => {
+      const appName = uniq('ionic-angular');
+      ensureNxProject('@nxtend/ionic-angular', 'dist/packages/ionic-angular');
+      await runCommandAsync('yarn add -D @nxtend/capacitor');
+      await runNxCommandAsync(
+        `generate @nxtend/ionic-angular:app --name ${appName} --capacitor false`
+      );
+      await runNxCommandAsync(
+        `generate @nxtend/ionic-angular:page --name my-page --project ${appName}`
+      );
+
+      await buildAndTestApp(appName);
+    });
+
+    describe('--directory', () => {
+      it('should create page in directory', async () => {
+        const appName = uniq('ionic-angular');
+        ensureNxProject('@nxtend/ionic-angular', 'dist/packages/ionic-angular');
+        await runCommandAsync('yarn add -D @nxtend/capacitor');
+        await runNxCommandAsync(
+          `generate @nxtend/ionic-angular:app --name ${appName} --capacitor false`
+        );
+        await runNxCommandAsync(
+          `generate @nxtend/ionic-angular:page --name my-page --project ${appName} --directory my-dir`
+        );
+
+        await buildAndTestApp(appName);
+      });
+    });
+  });
 });

--- a/packages/ionic-angular/CHANGELOG.md
+++ b/packages/ionic-angular/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 13.1.0
+
+- add page generator (courtesy of @joshuamorony)
+
 # 13.0.0
 
 ## Features

--- a/packages/ionic-angular/generators.json
+++ b/packages/ionic-angular/generators.json
@@ -21,6 +21,11 @@
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
       "description": "Create an Ionic Angular application."
+    },
+    "page": {
+      "factory": "./src/generators/page/generator#pageSchematic",
+      "schema": "./src/generators/page/schema.json",
+      "description": "Generate an Ionic page component"
     }
   }
 }

--- a/packages/ionic-angular/generators.json
+++ b/packages/ionic-angular/generators.json
@@ -8,6 +8,11 @@
       "schema": "./src/generators/application/schema.json",
       "aliases": ["app"],
       "description": "Create an Ionic Angular application."
+    },
+    "page": {
+      "factory": "./src/generators/page/generator",
+      "schema": "./src/generators/page/schema.json",
+      "description": "Generate an Ionic page component"
     }
   },
   "schematics": {

--- a/packages/ionic-angular/src/generators/page/files/__name__-routing.module.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__-routing.module.ts.template
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { MyPagePage } from './my-page.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: MyPagePage
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class MyPagePageRoutingModule {}

--- a/packages/ionic-angular/src/generators/page/files/__name__-routing.module.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__-routing.module.ts.template
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
-import { MyPagePage } from './my-page.page';
+import { <%= className %>Page } from './<%= fileName %>.page';
 
 const routes: Routes = [
   {
     path: '',
-    component: MyPagePage
+    component: <%= className %>Page
   }
 ];
 
@@ -14,4 +14,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],
 })
-export class MyPagePageRoutingModule {}
+export class <%= className %>PageRoutingModule {}

--- a/packages/ionic-angular/src/generators/page/files/__name__.module.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.module.ts.template
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { MyPagePageRoutingModule } from './my-page-routing.module';
+
+import { MyPagePage } from './my-page.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    MyPagePageRoutingModule
+  ],
+  declarations: [MyPagePage]
+})
+export class MyPagePageModule {}

--- a/packages/ionic-angular/src/generators/page/files/__name__.module.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.module.ts.template
@@ -4,17 +4,17 @@ import { FormsModule } from '@angular/forms';
 
 import { IonicModule } from '@ionic/angular';
 
-import { MyPagePageRoutingModule } from './my-page-routing.module';
+import { <%= className %>PageRoutingModule } from './<%= fileName %>-routing.module';
 
-import { MyPagePage } from './my-page.page';
+import { <%= className %>Page } from './<%= fileName %>.page';
 
 @NgModule({
   imports: [
     CommonModule,
     FormsModule,
     IonicModule,
-    MyPagePageRoutingModule
+    <%= className %>PageRoutingModule
   ],
-  declarations: [MyPagePage]
+  declarations: [<%= className %>Page]
 })
-export class MyPagePageModule {}
+export class <%= className %>PageModule {}

--- a/packages/ionic-angular/src/generators/page/files/__name__.page.html.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.page.html.template
@@ -1,0 +1,9 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>MyPage</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+
+</ion-content>

--- a/packages/ionic-angular/src/generators/page/files/__name__.page.html.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.page.html.template
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>MyPage</ion-title>
+    <ion-title><%= className %></ion-title>
   </ion-toolbar>
 </ion-header>
 

--- a/packages/ionic-angular/src/generators/page/files/__name__.page.spec.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.page.spec.ts.template
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { MyPagePage } from './my-page.page';
+
+describe('MyPagePage', () => {
+  let component: MyPagePage;
+  let fixture: ComponentFixture<MyPagePage>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MyPagePage ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MyPagePage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/ionic-angular/src/generators/page/files/__name__.page.spec.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.page.spec.ts.template
@@ -1,19 +1,19 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
-import { MyPagePage } from './my-page.page';
+import { <%= className %>Page } from './<%= fileName %>.page';
 
-describe('MyPagePage', () => {
-  let component: MyPagePage;
-  let fixture: ComponentFixture<MyPagePage>;
+describe('<%= className %>Page', () => {
+  let component: <%= className %>Page;
+  let fixture: ComponentFixture<<%= className %>Page>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ MyPagePage ],
+      declarations: [ <%= className %>Page ],
       imports: [IonicModule.forRoot()]
     }).compileComponents();
 
-    fixture = TestBed.createComponent(MyPagePage);
+    fixture = TestBed.createComponent(<%= className %>Page);
     component = fixture.componentInstance;
     fixture.detectChanges();
   }));

--- a/packages/ionic-angular/src/generators/page/files/__name__.page.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.page.ts.template
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-my-page',
+  templateUrl: './my-page.page.html',
+  styleUrls: ['./my-page.page.scss'],
+})
+export class MyPagePage implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/packages/ionic-angular/src/generators/page/files/__name__.page.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.page.ts.template
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-<%= fileName %>',
+  selector: '<%= prefix %>-<%= fileName %>',
   templateUrl: './<%= fileName %>.page.html',
   styleUrls: ['./<%= fileName %>.page.scss'],
 })

--- a/packages/ionic-angular/src/generators/page/files/__name__.page.ts.template
+++ b/packages/ionic-angular/src/generators/page/files/__name__.page.ts.template
@@ -1,11 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-my-page',
-  templateUrl: './my-page.page.html',
-  styleUrls: ['./my-page.page.scss'],
+  selector: 'app-<%= fileName %>',
+  templateUrl: './<%= fileName %>.page.html',
+  styleUrls: ['./<%= fileName %>.page.scss'],
 })
-export class MyPagePage implements OnInit {
+export class <%= className %>Page implements OnInit {
 
   constructor() { }
 

--- a/packages/ionic-angular/src/generators/page/generator.spec.ts
+++ b/packages/ionic-angular/src/generators/page/generator.spec.ts
@@ -1,7 +1,7 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Tree } from '@nrwl/devkit';
+import { names, Tree } from '@nrwl/devkit';
 
-import generator from './generator';
+import { pageGenerator } from './generator';
 import { PageGeneratorSchema } from './schema';
 import { ApplicationGeneratorSchema } from '../application/schema';
 import { applicationGenerator } from '../application/generator';
@@ -27,7 +27,7 @@ describe('page generator', () => {
   });
 
   it('should create page files', async () => {
-    await generator(appTree, options);
+    await pageGenerator(appTree, options);
 
     expect(
       appTree.exists(
@@ -66,9 +66,19 @@ describe('page generator', () => {
     ).toBeTruthy();
   });
 
+  it('should add route to app-routing module', async () => {
+    await pageGenerator(appTree, options);
+
+    const appRoutingFilePath = `${projectRoot}/src/app/app-routing.module.ts`;
+
+    expect(appTree.read(appRoutingFilePath, 'utf-8')).toContain(
+      `${names(options.name).className}PageModule`
+    );
+  });
+
   describe('--directory', () => {
     it('should create page files inside directory', async () => {
-      await generator(appTree, { ...options, directory: 'myDir' });
+      await pageGenerator(appTree, { ...options, directory: 'myDir' });
 
       expect(
         appTree.exists(

--- a/packages/ionic-angular/src/generators/page/generator.spec.ts
+++ b/packages/ionic-angular/src/generators/page/generator.spec.ts
@@ -1,0 +1,103 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { Tree, readProjectConfiguration } from '@nrwl/devkit';
+
+import generator from './generator';
+import { PageGeneratorSchema } from './schema';
+
+describe('page generator', () => {
+  let appTree: Tree;
+  const options: PageGeneratorSchema = { project: 'test', name: 'test' };
+  const projectRoot = `apps/${options.project}`;
+
+  beforeEach(() => {
+    appTree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should run successfully', async () => {
+    await generator(appTree, options);
+    const config = readProjectConfiguration(appTree, 'test');
+    expect(config).toBeDefined();
+  });
+
+  it('should create page files', async () => {
+    await generator(appTree, options);
+
+    expect(
+      appTree.exists(
+        `${projectRoot}/src/app/${options.name}/${options.name}-routing.module.ts`
+      )
+    ).toBeTruthy();
+
+    expect(
+      appTree.exists(
+        `${projectRoot}/src/app/${options.name}/${options.name}.page.html`
+      )
+    ).toBeTruthy();
+
+    expect(
+      appTree.exists(
+        `${projectRoot}/src/app/${options.name}/${options.name}.page.spec.ts`
+      )
+    ).toBeTruthy();
+
+    expect(
+      appTree.exists(
+        `${projectRoot}/src/app/${options.name}/${options.name}.module.ts`
+      )
+    ).toBeTruthy();
+
+    expect(
+      appTree.exists(
+        `${projectRoot}/src/app/${options.name}/${options.name}.page.scss`
+      )
+    ).toBeTruthy();
+
+    expect(
+      appTree.exists(
+        `${projectRoot}/src/app/${options.name}/${options.name}.page.ts`
+      )
+    ).toBeTruthy();
+  });
+
+  describe('--directory', () => {
+    it('should create page files', async () => {
+      await generator(appTree, { ...options, directory: 'myDir' });
+
+      expect(
+        appTree.exists(
+          `${projectRoot}/src/app/myDir/${options.name}/${options.name}-routing.module.ts`
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          `${projectRoot}/src/app/myDir/${options.name}/${options.name}.page.html`
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          `${projectRoot}/src/app/myDir/${options.name}/${options.name}.page.spec.ts`
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          `${projectRoot}/src/app/myDir/${options.name}/${options.name}.module.ts`
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          `${projectRoot}/src/app/myDir/${options.name}/${options.name}.page.scss`
+        )
+      ).toBeTruthy();
+
+      expect(
+        appTree.exists(
+          `${projectRoot}/src/app/myDir/${options.name}/${options.name}.page.ts`
+        )
+      ).toBeTruthy();
+    });
+  });
+});

--- a/packages/ionic-angular/src/generators/page/generator.spec.ts
+++ b/packages/ionic-angular/src/generators/page/generator.spec.ts
@@ -1,5 +1,5 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { names, Tree } from '@nrwl/devkit';
+import { Tree } from '@nrwl/devkit';
 
 import { pageGenerator } from './generator';
 import { PageGeneratorSchema } from './schema';
@@ -64,16 +64,6 @@ describe('page generator', () => {
         `${projectRoot}/src/app/${options.name}/${options.name}.page.ts`
       )
     ).toBeTruthy();
-  });
-
-  it('should add route to app-routing module', async () => {
-    await pageGenerator(appTree, options);
-
-    const appRoutingFilePath = `${projectRoot}/src/app/app-routing.module.ts`;
-
-    expect(appTree.read(appRoutingFilePath, 'utf-8')).toContain(
-      `${names(options.name).className}PageModule`
-    );
   });
 
   describe('--directory', () => {

--- a/packages/ionic-angular/src/generators/page/generator.spec.ts
+++ b/packages/ionic-angular/src/generators/page/generator.spec.ts
@@ -1,22 +1,29 @@
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nrwl/devkit';
+import { Tree } from '@nrwl/devkit';
 
 import generator from './generator';
 import { PageGeneratorSchema } from './schema';
+import { ApplicationGeneratorSchema } from '../application/schema';
+import { applicationGenerator } from '../application/generator';
 
 describe('page generator', () => {
   let appTree: Tree;
-  const options: PageGeneratorSchema = { project: 'test', name: 'test' };
+
+  const projectOptions: ApplicationGeneratorSchema = {
+    name: 'my-app',
+    template: 'blank',
+    unitTestRunner: 'jest',
+    e2eTestRunner: 'cypress',
+    capacitor: false,
+    skipFormat: false,
+  };
+
+  const options: PageGeneratorSchema = { project: 'my-app', name: 'test' };
   const projectRoot = `apps/${options.project}`;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     appTree = createTreeWithEmptyWorkspace();
-  });
-
-  it('should run successfully', async () => {
-    await generator(appTree, options);
-    const config = readProjectConfiguration(appTree, 'test');
-    expect(config).toBeDefined();
+    await applicationGenerator(appTree, projectOptions);
   });
 
   it('should create page files', async () => {
@@ -60,7 +67,7 @@ describe('page generator', () => {
   });
 
   describe('--directory', () => {
-    it('should create page files', async () => {
+    it('should create page files inside directory', async () => {
       await generator(appTree, { ...options, directory: 'myDir' });
 
       expect(

--- a/packages/ionic-angular/src/generators/page/generator.ts
+++ b/packages/ionic-angular/src/generators/page/generator.ts
@@ -7,11 +7,8 @@ import {
   Tree,
 } from '@nrwl/devkit';
 import * as path from 'path';
-import { PageGeneratorSchema } from './schema';
-
-interface NormalizedSchema extends PageGeneratorSchema {
-  projectRoot: string;
-}
+import { updateAppRoutingModule } from './lib/update-routing-file';
+import { NormalizedSchema, PageGeneratorSchema } from './schema';
 
 function normalizeOptions(
   tree: Tree,
@@ -50,5 +47,7 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
 export default async function (tree: Tree, options: PageGeneratorSchema) {
   const normalizedOptions = normalizeOptions(tree, options);
   addFiles(tree, normalizedOptions);
+  updateAppRoutingModule(tree, normalizedOptions);
+
   await formatFiles(tree);
 }

--- a/packages/ionic-angular/src/generators/page/generator.ts
+++ b/packages/ionic-angular/src/generators/page/generator.ts
@@ -44,10 +44,12 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
   generateFiles(tree, path.join(__dirname, 'files'), pageDir, templateOptions);
 }
 
-export default async function (tree: Tree, options: PageGeneratorSchema) {
+export async function pageGenerator(tree: Tree, options: PageGeneratorSchema) {
   const normalizedOptions = normalizeOptions(tree, options);
   addFiles(tree, normalizedOptions);
   updateAppRoutingModule(tree, normalizedOptions);
 
   await formatFiles(tree);
 }
+
+export default pageGenerator;

--- a/packages/ionic-angular/src/generators/page/generator.ts
+++ b/packages/ionic-angular/src/generators/page/generator.ts
@@ -1,4 +1,5 @@
 import {
+  convertNxGenerator,
   formatFiles,
   generateFiles,
   getWorkspaceLayout,
@@ -55,3 +56,4 @@ export async function pageGenerator(tree: Tree, options: PageGeneratorSchema) {
 }
 
 export default pageGenerator;
+export const pageSchematic = convertNxGenerator(pageGenerator);

--- a/packages/ionic-angular/src/generators/page/generator.ts
+++ b/packages/ionic-angular/src/generators/page/generator.ts
@@ -14,11 +14,13 @@ function normalizeOptions(
   tree: Tree,
   options: PageGeneratorSchema
 ): NormalizedSchema {
-  const projectRoot = `${getWorkspaceLayout(tree).appsDir}/${options.project}`;
+  const { appsDir, npmScope } = getWorkspaceLayout(tree);
+  const projectRoot = `${appsDir}/${options.project}`;
 
   return {
     ...options,
     projectRoot,
+    prefix: npmScope,
   };
 }
 

--- a/packages/ionic-angular/src/generators/page/generator.ts
+++ b/packages/ionic-angular/src/generators/page/generator.ts
@@ -1,0 +1,54 @@
+import {
+  formatFiles,
+  generateFiles,
+  getWorkspaceLayout,
+  names,
+  offsetFromRoot,
+  Tree,
+} from '@nrwl/devkit';
+import * as path from 'path';
+import { PageGeneratorSchema } from './schema';
+
+interface NormalizedSchema extends PageGeneratorSchema {
+  projectRoot: string;
+}
+
+function normalizeOptions(
+  tree: Tree,
+  options: PageGeneratorSchema
+): NormalizedSchema {
+  const projectRoot = `${getWorkspaceLayout(tree).appsDir}/${options.project}`;
+
+  return {
+    ...options,
+    projectRoot,
+  };
+}
+
+function addFiles(tree: Tree, options: NormalizedSchema) {
+  const templateOptions = {
+    ...options,
+    ...names(options.name),
+    name: names(options.name).fileName,
+    offsetFromRoot: offsetFromRoot(options.projectRoot),
+    template: '',
+  };
+
+  const pageDir = options.directory
+    ? path.join(
+        options.projectRoot,
+        `/src/app/${options.directory}/${names(options.name).fileName}`
+      )
+    : path.join(
+        options.projectRoot,
+        `/src/app/${names(options.name).fileName}`
+      );
+
+  generateFiles(tree, path.join(__dirname, 'files'), pageDir, templateOptions);
+}
+
+export default async function (tree: Tree, options: PageGeneratorSchema) {
+  const normalizedOptions = normalizeOptions(tree, options);
+  addFiles(tree, normalizedOptions);
+  await formatFiles(tree);
+}

--- a/packages/ionic-angular/src/generators/page/lib/update-routing-file.ts
+++ b/packages/ionic-angular/src/generators/page/lib/update-routing-file.ts
@@ -10,7 +10,6 @@ import {
 import * as path from 'path';
 
 export function updateAppRoutingModule(tree: Tree, options: NormalizedSchema) {
-  // Update app routing
   const appRoutingModuleFilePath = path.join(
     options.projectRoot,
     `/src/app/app-routing.module.ts`
@@ -44,7 +43,6 @@ export function updateAppRoutingModule(tree: Tree, options: NormalizedSchema) {
           if (arrLiteral.elements.length > 0) {
             const nodeArray = arrLiteral.elements;
 
-            // Insert new route
             const insertPosition = nodeArray[0].getStart();
 
             const previousRoutes = vsNode.getFullText();

--- a/packages/ionic-angular/src/generators/page/lib/update-routing-file.ts
+++ b/packages/ionic-angular/src/generators/page/lib/update-routing-file.ts
@@ -1,0 +1,65 @@
+import { names, Tree } from '@nrwl/devkit';
+import { readFileIfExisting } from '@nrwl/workspace/src/core/file-utils';
+import { tsquery } from '@phenomnomnominal/tsquery';
+import { NormalizedSchema } from '../schema';
+import {
+  ArrayLiteralExpression,
+  Identifier,
+  VariableStatement,
+} from 'typescript';
+import * as path from 'path';
+
+export function updateAppRoutingModule(tree: Tree, options: NormalizedSchema) {
+  // Update app routing
+  const appRoutingModuleFilePath = path.join(
+    options.projectRoot,
+    `/src/app/app-routing.module.ts`
+  );
+
+  const appRoutingModule = readFileIfExisting(appRoutingModuleFilePath);
+
+  if (appRoutingModule !== '') {
+    const newContents = tsquery.replace(
+      appRoutingModule,
+      'VariableStatement',
+      (node) => {
+        const vsNode = node as VariableStatement;
+        const declarations = vsNode.declarationList.declarations[0];
+
+        if ((declarations.name as Identifier).escapedText === 'routes') {
+          const pageNames = names(options.name);
+          const importPath = options.directory
+            ? `./${options.directory}/${pageNames.fileName}/${pageNames.fileName}.module`
+            : `./${pageNames.fileName}/${pageNames.fileName}.module`;
+
+          const toInsert = `{
+            path: '${pageNames.fileName}',
+            loadChildren: () =>
+              import('${importPath}').then((m) => m.${pageNames.className}PageModule),
+          },
+          `;
+
+          const arrLiteral = declarations.initializer as ArrayLiteralExpression;
+
+          if (arrLiteral.elements.length > 0) {
+            const nodeArray = arrLiteral.elements;
+
+            // Insert new route
+            const insertPosition = nodeArray[0].getStart();
+
+            const previousRoutes = vsNode.getFullText();
+            const prefix = previousRoutes.substring(0, insertPosition);
+            const suffix = previousRoutes.substring(insertPosition);
+            const newRoutes = `${prefix}${toInsert}${suffix}`;
+
+            return newRoutes;
+          }
+        }
+      }
+    );
+
+    if (newContents !== appRoutingModule) {
+      tree.write(appRoutingModuleFilePath, newContents);
+    }
+  }
+}

--- a/packages/ionic-angular/src/generators/page/schema.d.ts
+++ b/packages/ionic-angular/src/generators/page/schema.d.ts
@@ -6,4 +6,5 @@ export interface PageGeneratorSchema {
 
 export interface NormalizedSchema extends PageGeneratorSchema {
   projectRoot: string;
+  prefix: string;
 }

--- a/packages/ionic-angular/src/generators/page/schema.d.ts
+++ b/packages/ionic-angular/src/generators/page/schema.d.ts
@@ -3,3 +3,7 @@ export interface PageGeneratorSchema {
   project: string;
   directory?: string;
 }
+
+export interface NormalizedSchema extends PageGeneratorSchema {
+  projectRoot: string;
+}

--- a/packages/ionic-angular/src/generators/page/schema.d.ts
+++ b/packages/ionic-angular/src/generators/page/schema.d.ts
@@ -1,0 +1,5 @@
+export interface PageGeneratorSchema {
+  name: string;
+  project: string;
+  directory?: string;
+}

--- a/packages/ionic-angular/src/generators/page/schema.json
+++ b/packages/ionic-angular/src/generators/page/schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "Page",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "alias": "p",
+      "$default": {
+        "$source": "projectName"
+      },
+      "x-prompt": "What is the name of the project for this page?"
+    },
+    "name": {
+      "type": "string",
+      "description": "",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use?"
+    },
+    "directory": {
+      "type": "string",
+      "description": "A directory where the page is created",
+      "alias": "d"
+    }
+  },
+  "required": ["project", "name"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4734,6 +4734,7 @@
     rxjs "6.5.5"
     typescript "4.3.5"
 
+<<<<<<< main
 "@parcel/watcher@2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.4.tgz#f300fef4cc38008ff4b8c29d92588eced3ce014b"
@@ -4743,6 +4744,9 @@
     node-gyp-build "^4.3.0"
 
 "@phenomnomnominal/tsquery@4.1.1":
+=======
+"@phenomnomnominal/tsquery@4.1.1", "@phenomnomnominal/tsquery@^4.1.1":
+>>>>>>> wip: added automatic route creation for page
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz#42971b83590e9d853d024ddb04a18085a36518df"
   integrity sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==


### PR DESCRIPTION
# Description

This is just about ready but I wanted to open a draft PR as there are a couple things I'm stuck on at the moment. I've implemented the same basic behaviour as the Ionic CLI for generating pages, but not all options are included at the moment (just the option to specify a directory). I'd like to add all of the options in the future as well (either pre or post merging this basic functionality), and possibly also an option to generate the page in a library instead of in the app itself.

Most of what I've added is reasonably standard, but the code I've added to dynamically add the new route to the app-routing file could require closer inspection. This is the first time I've used an AST to modify a file, it seems to be working as intended but perhaps it could be improved.

The generator is fully working as intended, but what I am stuck on now is the tests. The unit test that tests that the new route is added to the app-routing file is failing and I don't know why. After running the generator in the test, the app-routing file appears to be unmodified, but actually running the generator outside of a test I can see that it works fine. I've also been unable to run the E2E tests - running the command just sits on this in the terminal:

```
 RUNS   ionic-angular-e2e  e2e/ionic-angular-e2e/tests/ionic-angular.spec.ts
```

Until it eventually times out.

I'll keep trying the figure out what is going on here, but if you have any feedback or ideas that'd be great!

# PR Checklist

- [] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [] Documentation has been updated if necessary
