### PR TITLE
Fix Angular dependency type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ yarn test {plugin}
 To run e2e tests for a plugin, run:
 
 ```
-yarn e2e {plugin}
+yarn e2e {plugin}-e2e
 ```
 
 ## Testing Locally

--- a/packages/ionic-angular/CHANGELOG.md
+++ b/packages/ionic-angular/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+# 13.1.1
+
+## Bug Fixes
+
+- move `@nrwl/angular` to dependencies section of `package.json`
+
 # 13.1.0
 
-# Features
+## Features
 
 - add page generator (courtesy of @joshuamorony)
 

--- a/packages/ionic-angular/package.json
+++ b/packages/ionic-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxtend/ionic-angular",
-  "version": "13.1.0",
+  "version": "13.1.1",
   "description": "An Nx plugin for developing Ionic React applications and libraries",
   "author": {
     "name": "Devin Shoemaker",

--- a/packages/ionic-angular/src/generators/application/generator.spec.ts
+++ b/packages/ionic-angular/src/generators/application/generator.spec.ts
@@ -24,7 +24,7 @@ describe('application schematic', () => {
 
     const packageJson = readJson(appTree, 'package.json');
     expect(packageJson.dependencies['@ionic/angular']).toBeDefined();
-    expect(packageJson.devDependencies['@nrwl/angular']).toBeDefined();
+    expect(packageJson.dependencies['@nrwl/angular']).toBeDefined();
     expect(packageJson.devDependencies['@nxtend/capacitor']).toBeDefined();
   });
 

--- a/packages/ionic-angular/src/generators/application/lib/add-dependencies.ts
+++ b/packages/ionic-angular/src/generators/application/lib/add-dependencies.ts
@@ -1,16 +1,26 @@
-import { addDependenciesToPackageJson, Tree } from '@nrwl/devkit';
+import { addDependenciesToPackageJson, readJson, Tree } from '@nrwl/devkit';
 import {
   ionicAngularVersion,
   nxtendCapacitorVersion,
   nxVersion,
 } from '../../../utils/versions';
 
+let packageJson;
+
+const isExistingDependency = (name: string) =>
+  packageJson?.dependencies?.[name] ? true : false;
+
 export function addDependencies(host: Tree) {
-  return addDependenciesToPackageJson(
-    host,
-    {
-      '@ionic/angular': ionicAngularVersion,
-    },
-    { '@nrwl/angular': nxVersion, '@nxtend/capacitor': nxtendCapacitorVersion }
-  );
+  packageJson = readJson(host, 'package.json');
+  let dependencies: Record<string, string> = {
+    '@ionic/angular': ionicAngularVersion,
+  };
+
+  if (!isExistingDependency('@nrwl/angular')) {
+    dependencies = { ...dependencies, '@nrwl/angular': nxVersion };
+  }
+
+  return addDependenciesToPackageJson(host, dependencies, {
+    '@nxtend/capacitor': nxtendCapacitorVersion,
+  });
 }


### PR DESCRIPTION
# Description

When creating an Nx workspace, the @nrwl/angular package is added to the _dependencies_ key in package.json. And when an application is added using @nxtend/ionic-angular it will unconditionally add it to _devDependencies_ key.

And a small fix in CONTRIBUTING file.

# PR Checklist

- [ ] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [x] Documentation has been updated if necessary

# Issue

See #621 for further information. 

Although I think this is an improvement, there may be an issue when 'nrwl' packages have a different version number from what 'nxtend' sets `@nrwl/angular`, when needed. Internally, 'nrwl' has a lot of checks for dependency mismatch, as seen [here](https://github.com/nrwl/nx/blob/master/packages/make-angular-cli-faster/src/utilities/package-manager.ts). I guess my point here, to me it seems 'nrwl' plugins are high maintenance. And more edits can and will be needed in the code that has been changed for this PR.

Resolves #621 
