### PR TITLE
release(firebase): 13.0.0

### DIFF
--- a/packages/firebase/README.md
+++ b/packages/firebase/README.md
@@ -23,7 +23,7 @@ Visit the official [Getting Started](https://nxtend.dev/docs/firebase/getting-st
 
 ## Contributing
 
-See [the contributing file](../../contributing.md)!
+See [the contributing file](../../CONTRIBUTING.md)!
 
 PRs accepted.
 

--- a/packages/firebase/package.json
+++ b/packages/firebase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxtend/firebase",
-  "version": "12.1.0",
+  "version": "13.0.0",
   "description": "An Nx plugin for developing cross-platform applications using Capacitor",
   "author": {
     "name": "Devin Shoemaker",


### PR DESCRIPTION
# Description

I see that the repo has `devkit@^13` dependency already but the latest published one (`v12.1.0`) still relies on `^12`, and the CHANGELOG already mentions the support for Nx 13 :eyes: 

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary
