### PR TITLE
Added missing parameter to run-commands

### DIFF
--- a/packages/firebase/src/executors/firebase/executor.ts
+++ b/packages/firebase/src/executors/firebase/executor.ts
@@ -16,6 +16,7 @@ export default async function runExecutor(
   const runCommandsOptions: RunCommandsBuilderOptions = {
     cwd: projectRootPath,
     command: `firebase ${cmd}`,
+    __unparsed__: [],
   };
 
   return await runCommands(runCommandsOptions, context);


### PR DESCRIPTION
NX added a new required __unparsed__ parameter to run-commands in v14.3.0, which causes errors. This fixes it, but it's very ugly.

# Description

# PR Checklist

- [x] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ ] Documentation has been updated if necessary

# Issue

Resolves #633
