### PR TITLE
fix(capacitor/firebase): add __unparsed__ property

### DIFF
--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -16,6 +16,7 @@ export default async function runExecutor(
   const runCommandsOptions: RunCommandsBuilderOptions = {
     cwd: projectRootPath,
     command: `npx cap ${cmd}`,
+    __unparsed__: [],
   };
 
   return await runCommands(runCommandsOptions, context);

--- a/packages/firebase/src/executors/firebase/executor.ts
+++ b/packages/firebase/src/executors/firebase/executor.ts
@@ -16,6 +16,7 @@ export default async function runExecutor(
   const runCommandsOptions: RunCommandsBuilderOptions = {
     cwd: projectRootPath,
     command: `firebase ${cmd}`,
+    __unparsed__: [],
   };
 
   return await runCommands(runCommandsOptions, context);


### PR DESCRIPTION
# Description

Adds `__unparsed__` property to run command options for capacitor and firebase executors.

Without this property, the executor fails with error message
'Cannot read properties of undefined (reading 'length')'

# PR Checklist

- [x] Migrations have been added if necessary
- [x] Unit tests have been added or updated if necessary
- [x] e2e tests have been added or updated if necessary
- [x] Changelog has been updated if necessary
- [x] Documentation has been updated if necessary

# Issue

Resolves #633
