### PR TITLE
fix(capacitor): ensure npx uses @capacitor/cli executable

### DIFF
--- a/apps/docs/docs/ionic-angular/capacitor.md
+++ b/apps/docs/docs/ionic-angular/capacitor.md
@@ -4,7 +4,7 @@ title: Capacitor
 sidebar_label: Capacitor
 ---
 
-By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx cap ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
+By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx --package=@capacitor/cli cap ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
 
 ## Add Native Platform
 

--- a/apps/docs/docs/ionic-react/capacitor.md
+++ b/apps/docs/docs/ionic-react/capacitor.md
@@ -4,7 +4,7 @@ title: Capacitor
 sidebar_label: Capacitor
 ---
 
-By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx cap ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
+By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx --package=@capacitor/cli cap ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
 
 ## Add Native Platform
 

--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -15,7 +15,7 @@ export default async function runExecutor(
 
   const runCommandsOptions: RunCommandsBuilderOptions = {
     cwd: projectRootPath,
-    command: `npx cap ${cmd}`,
+    command: `npx --package=@capacitor/cli cap ${cmd}`,
   };
 
   return await runCommands(runCommandsOptions, context);


### PR DESCRIPTION
# Description

As stated in linked issue, nxtend can try to use wrong `cap` executable since it cannot know which package this executable is referenced to.

# PR Checklist

- [ ] Migrations have been added if necessary
- [ ] Unit tests have been added or updated if necessary
- [ ] e2e tests have been added or updated if necessary
- [ ] Changelog has been updated if necessary
- [ x] Documentation has been updated if necessary

# Issue

Resolves #643
